### PR TITLE
[DEV-5047] Relax the requirements on CodeCheckRunStatistics.count

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9783,7 +9783,6 @@ components:
       properties:
         count:
           description: Number of executions with respect to `date_from` and `date_to`.
-          minimum: 1
           type: integer
         successes:
           description: Number of successful executions with respect to `date_from`


### PR DESCRIPTION
We count `skips` separately.