### PR TITLE
[DEV-5225] Add include_tlo query param to list_goal_templates op.

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1245,6 +1245,13 @@ paths:
       x-openapi-router-controller: athenian.api.controllers.goal_controller
     parameters:
     - $ref: '#/components/parameters/pathAccountID'
+    - description: Include templates for TLOs goals, i.e. goals based on parameterized metrics.
+      in: query
+      name: include_tlo
+      required: false
+      schema:
+        default: false
+        type: boolean
   /histograms/code_checks:
     post:
       operationId: calc_histogram_code_checks


### PR DESCRIPTION
Add `include_tlo` query parameter to include new goal templates in the response.
This allows the new templates to be deployed in API without breaking frontend.
When frontend is ready it can send `include_tlo=true`

Parameter will be removed after.