### PR TITLE
[DEV-5365] Create alias metrics pr-live-cycle-*

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3572,7 +3572,10 @@ components:
         * `pr-cycle-time`: Cycle Time - sum of correspodning `pr-wip-time`, `pr-review-time`, `pr-merging-time`, and `pr-release-time`.
         * `pr-cycle-count`: number of PRs used to calculate `pr-cycle-time` disregarding the quantiles. It equals to the overall number of PRs observed in the given time window.
         * `pr-cycle-count-q`: number of PRs used to calculate `pr-cycle-time` after applying the quantiles.
-        * `pr-all-count`: equals to the sum of `pr-cycle-count` with the number of PRs which are still not done on the specified time interval but don't have any stage-changing events. This metric should be exactly the same as the number of PRs returned by `/filter/prs`. The quantiles are ignored.
+        * `pr-live-cycle-time`: Live Cycle Time - sum of corresponding `pr-wip-time`, `pr-review-time`, `pr-merging-time`, and `pr-release-time`.
+        * `pr-live-cycle-count`: number of PRs used to calculate `pr-cycle-time` disregarding the quantiles. It equals to the overall number of PRs observed in the given time window.
+        * `pr-live-cycle-count-q`: number of PRs used to calculate `pr-cycle-time` after applying the quantiles.
+        * `pr-all-count`: equals to the sum of `pr-live-cycle-count` with the number of PRs which are still not done on the specified time interval but don't have any stage-changing events. This metric should be exactly the same as the number of PRs returned by `/filter/prs`. The quantiles are ignored.
         * `pr-wait-first-review-time`: average time of waiting for the first review.
         * `pr-wait-first-review-count`: number of PRs used to calculate `pr-wait-first-review`. Note: this is *not* the same as the number of PRs waiting for the first review.
         * `pr-wait-first-review-count-q`: number of PRs used to calculate `pr-wait-first-review` after applying the quantiles.


### PR DESCRIPTION
Add alias for pr-cycle-* metrics as pr-live-cycle-*
This is the first step to rename pr-lead-* metrics to pr-cycle-*